### PR TITLE
Fix false-positive dead-lettering of stored replies (#24, #25)

### DIFF
--- a/src/main/java/org/hastingtx/meshrelay/OpenBrainStore.java
+++ b/src/main/java/org/hastingtx/meshrelay/OpenBrainStore.java
@@ -20,9 +20,11 @@ import java.util.logging.Logger;
  * purpose-built messages table, which provides native thread_id tracking,
  * inbox-style retrieval, and proper delivery state.
  *
- * KNOWN LIMITATION: there is no "reset to pending" in the messages table API.
- * If processing fails after markDelivered(), the message stays in "delivered"
- * state and will not be retried automatically. See MessagePoller for details.
+ * Retry contract: a message claimed via markDelivered() that then fails
+ * processing is returned to "pending" by resetDelivered() (via the OpenBrain
+ * mark_pending tool) so the next poll retries it. Only if that reset is
+ * unavailable does the message fall through to the dead-letter path. See
+ * MessagePoller for details.
  *
  * FIXED (2026-04-13): send_message previously returned None on macmini due to a
  * PostgreSQL CTE snapshot-isolation bug in tools/messaging.py. The outer UPDATE
@@ -188,9 +190,8 @@ public class OpenBrainStore {
      * This is the atomic "claim" step — once delivered, subsequent get_inbox
      * calls will not return this message, preventing duplicate processing.
      *
-     * NOTE: Unlike the previous claimMessage() / resetMessage() pair, the
-     * messages table has no "reset to pending" operation. If processing fails
-     * after markDelivered(), the message stays in "delivered" state. See
+     * NOTE: if processing fails after markDelivered(), {@link #resetDelivered}
+     * returns the message to "pending" so it is retried on the next poll. See
      * MessagePoller for how this case is handled.
      *
      * Returns true if the server accepted the update, false on network error.
@@ -224,30 +225,54 @@ public class OpenBrainStore {
     }
 
     /**
-     * Reset a "delivered" message back to "pending" for retry.
+     * Reset a "delivered" message back to "pending" for retry (messenger#25).
      *
-     * NOT IMPLEMENTED — the OpenBrain messages API has no mark_pending operation.
-     * This stub documents the required capability and owns the correct call site.
-     * When macmini adds mark_pending to the OpenBrain MCP, replace the body with:
-     *
-     *   String body = "{\"tool\":\"mark_pending\",\"message_id\":%d}".formatted(messageId);
-     *   POST to mcpUrl with brainKey header
-     *   return resp.statusCode() == 200;
+     * Calls the OpenBrain {@code mark_pending} tool (openbrain-mcp#33), the
+     * mirror of {@link #markDelivered}. The server only transitions a message
+     * that is currently {@code delivered}; if the row is in any other state
+     * (e.g. already {@code archived}) it returns an {@code error} envelope and
+     * we report failure so the caller dead-letters rather than silently drops.
      *
      * Callers check the return value:
      *   true  → message is pending again; will be retried on the next poll
-     *   false → reset unavailable; caller falls through to the dead-letter path
+     *   false → reset unavailable/rejected; caller falls through to dead-letter
      *
-     * Feature request filed: OpenBrain thought #mark-pending-feature-request
-     * See ARCHITECTURE.md §4.3 for the failure contract this enables.
-     *
-     * @return false always (not implemented)
+     * @return true if the message was returned to pending, false otherwise
      */
     public boolean resetDelivered(int messageId) {
-        // TODO: implement when macmini adds mark_pending to the messages API
-        log.warning("resetDelivered() not implemented — message_id=" + messageId
-            + " remains 'delivered'; falling through to dead-letter path");
-        return false;
+        try {
+            String body = """
+                {"tool":"mark_pending","message_id":%d}
+                """.formatted(messageId);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(mcpUrl))
+                .timeout(TIMEOUT)
+                .header("Content-Type", "application/json")
+                .header("x-brain-key", brainKey)
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build();
+
+            HttpResponse<String> resp = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200) {
+                log.warning("resetDelivered: mark_pending HTTP " + resp.statusCode()
+                    + " for message_id=" + messageId + " — falling through to dead-letter");
+                return false;
+            }
+            // mark_pending returns an {"error":...} envelope (HTTP 200) when the
+            // message was not in 'delivered' state. Treat that as "cannot retry".
+            if (resp.body() != null && resp.body().contains("\"error\"")) {
+                log.warning("resetDelivered: mark_pending rejected message_id=" + messageId
+                    + ": " + resp.body() + " — falling through to dead-letter");
+                return false;
+            }
+            log.info("Reset message " + messageId + " to pending — will retry on next poll");
+            return true;
+        } catch (Exception e) {
+            log.warning("resetDelivered failed for message_id=" + messageId
+                + ": " + e.getMessage() + " — falling through to dead-letter");
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/hastingtx/meshrelay/RelayHandler.java
+++ b/src/main/java/org/hastingtx/meshrelay/RelayHandler.java
@@ -22,11 +22,15 @@ import java.util.logging.Logger;
  *
  * Flow:
  *   1. Store full message in OpenBrain → receive thread_id
- *   2. Send a tiny wake-up ping to the target peer: {from, thread_id}
- *   3. Return {thread_id, stored, wakeup_sent} to caller
+ *   2. Dispatch a tiny wake-up ping to the target peer ({from, thread_id})
+ *      on a background virtual thread
+ *   3. Return {thread_id, stored, wakeup_dispatched} to caller immediately
  *
- * The message is durable after step 1. A failed wake-up (step 2) is NOT
- * a delivery failure — the peer will pick up the message on its next poll.
+ * The message is durable after step 1. The wake-up (step 2) is a best-effort
+ * latency optimisation — the peer will pick up the message on its next poll
+ * regardless — so it runs asynchronously and never delays (or fails) the
+ * response. Running it inline previously coupled it to the caller's HTTP
+ * timeout and dead-lettered already-stored replies (messenger#24).
  *
  * Expected request body:
  * {
@@ -37,9 +41,9 @@ import java.util.logging.Logger;
  *
  * Response:
  * {
- *   "thread_id":    462,
- *   "stored":       true,
- *   "wakeup_sent":  true
+ *   "thread_id":         462,
+ *   "stored":            true,
+ *   "wakeup_dispatched": true
  * }
  */
 public class RelayHandler implements HttpHandler {
@@ -148,18 +152,33 @@ public class RelayHandler implements HttpHandler {
             return;
         }
 
-        // --- Step 2: Send wake-up ping to peer ---
-        // Best-effort with retries. Failure here is NOT a delivery failure.
-        boolean wakeupSent = sendWakeup(toNode, targetUrl, fromNode, stored.threadId());
+        // --- Step 2: Wake up the peer asynchronously ---
+        // The message is durable after step 1, so the wake-up is a pure latency
+        // optimisation — the peer's poll loop is the guaranteed delivery path.
+        // It MUST NOT run on this request thread: a slow or unreachable peer
+        // makes sendWakeup() retry for ~12-16s (3 attempts × connect/request
+        // timeouts + backoff), which would push this handler past the caller's
+        // HTTP timeout (ClaudeCliProcessor.sendReply caps the POST at 15s). The
+        // caller would then see a timeout and dead-letter a reply that was
+        // already durably stored above — the root cause of the 2026-05-29
+        // lost-email incident (messenger#24). Dispatching on a virtual thread
+        // lets us return 200 the instant the message is durable.
+        final String wakePeer   = toNode;
+        final String wakeUrl    = targetUrl;
+        final String wakeFrom   = fromNode;
+        final long   wakeThread = stored.threadId();
+        Thread.ofVirtual()
+            .name("wakeup-" + wakePeer + "-" + wakeThread)
+            .start(() -> sendWakeup(wakePeer, wakeUrl, wakeFrom, wakeThread));
 
-        // --- Step 3: Respond to caller ---
+        // --- Step 3: Respond to caller immediately (message already durable) ---
         String response = """
-            {"thread_id":%d,"message_id":%d,"stored":true,"wakeup_sent":%b}
-            """.formatted(stored.threadId(), stored.messageId(), wakeupSent).trim();
+            {"thread_id":%d,"message_id":%d,"stored":true,"wakeup_dispatched":true}
+            """.formatted(stored.threadId(), stored.messageId()).trim();
 
         byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
         exchange.getResponseHeaders().set("Content-Type", "application/json");
-        // 200 whether or not wake-up succeeded — message is stored either way
+        // 200 as soon as the message is durable — the wake-up runs in the background
         exchange.sendResponseHeaders(200, bytes.length);
         exchange.getResponseBody().write(bytes);
         exchange.close();


### PR DESCRIPTION
Fixes #24, fixes #25. Depends on richardahasting/openbrain-mcp#33 (mark_pending — already deployed on macmini).

## Context
On 2026-05-29 a request from macbook-air asking Lenny to send an email was lost: every retry (threads 762–786) landed in the dead-letter queue even though the reply was being durably stored. Root cause was two layered bugs.

## #24 — synchronous wake-up vs. caller timeout
`RelayHandler.handle()` ran `sendWakeup()` **inline** before returning 200. For an unreachable peer the retry budget is ~12–16s, but `ClaudeCliProcessor.sendReply()` caps the local `/relay` POST at 15s. The message was durable after the OpenBrain store (step 1), yet the synchronous wake-up blew past the caller's timeout → `sendReply` threw `request timed out` → the poller dead-lettered an already-delivered reply.

**Fix:** dispatch `sendWakeup()` on a virtual thread; return 200 the instant the message is durable. The wake-up stays best-effort (the peer's poll loop is the guaranteed delivery path).

**Verified:** `/relay` to a connect-timeout peer (192.168.0.62:13009) now returns `200` in **0.025s**; the 3 wake-up retries run in the background afterward (~16s); **no dead-letter** created. Old code would have blocked ~16s and dead-lettered.

## #25 — resetDelivered() permanent stub
`OpenBrainStore.resetDelivered()` returned `false` unconditionally, forcing every processing failure straight to dead-letter with no retry (even transient ones, e.g. the post-JDK-upgrade `jspawnhelper` failure). Implemented against the new `mark_pending` tool: a failed message returns to `pending` and is retried next poll; `MAX_TURNS_PER_THREAD` bounds a deterministically-failing message.

## Tests
Full suite green (RelayHandlerTest 22, OpenBrainStoreTest, MessagePollerTest 35, ClaudeCliProcessorTest 22, …). `wakeup_sent` response field → `wakeup_dispatched` (no consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)