### PR TITLE
Fix poller head-of-line blocking (#27)

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -86,7 +86,16 @@ def msg_health() -> dict:
 @mcp.tool()
 def msg_ping() -> dict:
     """Quick liveness check — is the local messenger daemon running?"""
-    return _get("/ping")
+    # Older daemons answer /ping with bare text "pong" (not JSON). Tolerate both
+    # so a version skew between the MCP wrapper and the daemon can't break the
+    # liveness probe. See messenger#27.
+    with httpx.Client(timeout=10) as client:
+        r = client.get(f"{MESSENGER_URL}/ping")
+        r.raise_for_status()
+        try:
+            return r.json()
+        except ValueError:
+            return {"status": "ok", "response": r.text.strip()}
 
 
 # --- Ask User (via Telegram) ---

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hastingtx</groupId>
     <artifactId>messenger</artifactId>
-    <version>1.1.6</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
     <description>Reliable agent-to-agent messaging daemon. Stores full messages in OpenBrain, delivers wake-up pings, polls every 10 minutes as catchup. Zero external dependencies.</description>
 

--- a/src/main/java/org/hastingtx/meshrelay/MeshRelay.java
+++ b/src/main/java/org/hastingtx/meshrelay/MeshRelay.java
@@ -147,7 +147,12 @@ public class MeshRelay {
         server.createContext("/wake",      new WakeHandler(config, poller));
         server.createContext("/health",    new HealthHandler(config, poller, java.time.Instant.now(), processor));
         server.createContext("/ping", exchange -> {
-            byte[] pong = "pong".getBytes(StandardCharsets.UTF_8);
+            // Return JSON (not bare "pong") so JSON-only clients like the Python
+            // MCP wrapper's msg_ping can parse the response. See messenger#27.
+            byte[] pong = ("{\"status\":\"ok\",\"node\":\"" + config.nodeName
+                + "\",\"version\":\"" + Version.VERSION + "\",\"response\":\"pong\"}")
+                .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
             exchange.sendResponseHeaders(200, pong.length);
             exchange.getResponseBody().write(pong);
             exchange.close();

--- a/src/main/java/org/hastingtx/meshrelay/MessagePoller.java
+++ b/src/main/java/org/hastingtx/meshrelay/MessagePoller.java
@@ -5,7 +5,9 @@ import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
@@ -26,12 +28,23 @@ import java.util.logging.Logger;
  *      after the current one completes. N simultaneous wake-ups collapse
  *      into at most 2 sequential runs — no double-processing.
  *
- *   2. Per-thread serialization:
+ *   2. Per-thread serialization with cross-thread concurrency:
  *      Messages belonging to the same conversation thread (same thread_id)
  *      are processed one at a time, in arrival order. This ensures an agent
  *      processing reply B always sees reply A fully committed first.
- *      Different threads are processed concurrently with no ordering
- *      constraint between them.
+ *      Different threads are processed concurrently — each message is handed
+ *      to its own virtual thread, so a long-running task on one thread does
+ *      NOT block other threads (or the poll loop itself). This is the fix for
+ *      messenger#27, where a multi-minute project agent on one thread left an
+ *      unrelated connectivity test (thread 812) stuck pending for the full
+ *      claude timeout. Total concurrency is bounded by a semaphore
+ *      (config.maxConcurrentProcessing) so a burst can't exhaust the machine.
+ *
+ *   3. Dispatch is non-blocking:
+ *      poll() claims each message into an in-flight set and dispatches it,
+ *      then returns immediately. The in-flight set prevents a subsequent
+ *      overlapping poll from re-dispatching a message before it has been
+ *      marked delivered.
  */
 public class MessagePoller implements Runnable {
 
@@ -43,8 +56,12 @@ public class MessagePoller implements Runnable {
     private final MessageProcessor processor;
 
     private volatile boolean running  = true;
-    private Instant lastPollTime      = Instant.EPOCH;
-    private int     totalProcessed    = 0;
+    // lastPollTime is written by the poll loop and read by the health endpoint;
+    // totalProcessed is now incremented from many processing virtual threads
+    // (messenger#27) — both must be safe for cross-thread visibility.
+    private volatile Instant lastPollTime = Instant.EPOCH;
+    private final java.util.concurrent.atomic.AtomicInteger totalProcessed =
+        new java.util.concurrent.atomic.AtomicInteger(0);
 
     // ── Concurrency controls ──────────────────────────────────────────────
 
@@ -68,6 +85,20 @@ public class MessagePoller implements Runnable {
      */
     private final ConcurrentHashMap<Long, ReentrantLock> threadLocks = new ConcurrentHashMap<>();
 
+    /**
+     * Message ids currently dispatched to a processing virtual thread (claimed
+     * but not yet completed). Guards against an overlapping poll re-dispatching
+     * the same message in the window before markDelivered() lands. Entries are
+     * removed when processing finishes (success, failure, or dead-letter).
+     */
+    private final Set<Integer> inFlight = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Bounds the number of messages processed concurrently. Each permit gates
+     * one {@code claude -p} subprocess. Sized from config.maxConcurrentProcessing.
+     */
+    private final Semaphore processingSlots;
+
     // ── Per-sender rate limiting ──────────────────────────────────────────
     // Prevents chatty agents (e.g. Gemma hallucinating tasks) from flooding
     // the processor. 3 messages per 10 minutes per sender.
@@ -82,6 +113,10 @@ public class MessagePoller implements Runnable {
         this.config    = config;
         this.brain     = brain;
         this.processor = processor;
+        int slots = Math.max(1, config.maxConcurrentProcessing);
+        // Fair semaphore: permits are granted in request order so a short task
+        // that arrived first isn't starved behind later long ones.
+        this.processingSlots = new Semaphore(slots, true);
     }
 
     /** Start the polling loop on a virtual thread. Returns immediately. */
@@ -218,8 +253,38 @@ public class MessagePoller implements Runnable {
                 brain.markArchived(msg.messageId());
                 continue;
             }
-            processWithThreadLock(msg);
+            dispatch(msg);
         }
+    }
+
+    /**
+     * Hand a message off to a background virtual thread for processing, then
+     * return immediately so the poll loop is never blocked by a slow task.
+     *
+     * The in-flight set is the dedup guard: if this message id is already being
+     * processed (e.g. an overlapping poll saw it before markDelivered landed),
+     * skip the duplicate dispatch. Same-thread ordering and serialization are
+     * still enforced inside processWithThreadLock via the per-thread lock; the
+     * global concurrency cap is enforced there via the processing semaphore.
+     */
+    private void dispatch(OpenBrainStore.PendingMessage msg) {
+        if (!inFlight.add(msg.messageId())) {
+            log.fine("Already in-flight — skipping duplicate dispatch message_id="
+                + msg.messageId() + " thread_id=" + msg.threadId());
+            return;
+        }
+        Thread.ofVirtual().name("msg-proc-" + msg.threadId()).start(() -> {
+            try {
+                processWithThreadLock(msg);
+            } catch (Throwable t) {
+                // processWithThreadLock handles its own exceptions; this is a
+                // last-resort guard so a bug can never leak a stuck in-flight entry.
+                log.warning("Unexpected error processing message_id=" + msg.messageId()
+                    + " thread_id=" + msg.threadId() + ": " + t);
+            } finally {
+                inFlight.remove(msg.messageId());
+            }
+        });
     }
 
     /**
@@ -262,7 +327,10 @@ public class MessagePoller implements Runnable {
      */
     private void processWithThreadLock(OpenBrainStore.PendingMessage msg) {
         long threadId = msg.threadId();
-        ReentrantLock lock = threadLocks.computeIfAbsent(threadId, id -> new ReentrantLock());
+        // Fair lock: when several messages of the same thread contend, they
+        // acquire in arrival order, preserving per-thread message ordering even
+        // though each runs on its own virtual thread.
+        ReentrantLock lock = threadLocks.computeIfAbsent(threadId, id -> new ReentrantLock(true));
         boolean acquired;
         try {
             acquired = lock.tryLock(THREAD_LOCK_TIMEOUT_MINUTES, TimeUnit.MINUTES);
@@ -301,16 +369,24 @@ public class MessagePoller implements Runnable {
             }
 
             try {
-                processor.process(msg);
+                // Bound concurrent claude subprocesses across all threads.
+                // Acquired only around the expensive processor call, not the
+                // cheap OpenBrain bookkeeping, so permits free up promptly.
+                processingSlots.acquire();
+                try {
+                    processor.process(msg);
+                } finally {
+                    processingSlots.release();
+                }
                 brain.markArchived(msg.messageId());
                 if ("all".equals(msg.toNode())) {
                     brain.updateBroadcastWatermark(config.nodeName, msg.messageId());
                 }
                 recordProcessed(msg.fromNode());
-                totalProcessed++;
+                int processed = totalProcessed.incrementAndGet();
                 log.info("Processed message thread_id=" + threadId
                     + " from=" + msg.fromNode()
-                    + " total_processed=" + totalProcessed);
+                    + " total_processed=" + processed);
             } catch (Exception e) {
                 log.warning("Failed to process message thread_id=" + threadId
                     + " messageId=" + msg.messageId() + ": " + e.getMessage());
@@ -338,5 +414,25 @@ public class MessagePoller implements Runnable {
     public void stop() { running = false; }
 
     public Instant getLastPollTime()   { return lastPollTime; }
-    public int     getTotalProcessed() { return totalProcessed; }
+    public int     getTotalProcessed() { return totalProcessed.get(); }
+
+    /** Number of messages currently dispatched but not yet finished processing. */
+    int inFlightCount() { return inFlight.size(); }
+
+    /**
+     * Block until all dispatched messages have finished processing, or the
+     * timeout elapses. Processing now runs on background virtual threads
+     * (messenger#27), so callers that need to observe the terminal state —
+     * tests, graceful shutdown — use this to await quiescence.
+     *
+     * @return true if processing drained within the timeout, false otherwise
+     */
+    boolean awaitProcessingComplete(long timeoutMillis) throws InterruptedException {
+        long deadline = System.nanoTime() + timeoutMillis * 1_000_000L;
+        while (!inFlight.isEmpty()) {
+            if (System.nanoTime() >= deadline) return false;
+            Thread.sleep(10);
+        }
+        return true;
+    }
 }

--- a/src/main/java/org/hastingtx/meshrelay/OpenBrainStore.java
+++ b/src/main/java/org/hastingtx/meshrelay/OpenBrainStore.java
@@ -226,28 +226,42 @@ public class OpenBrainStore {
     /**
      * Reset a "delivered" message back to "pending" for retry.
      *
-     * NOT IMPLEMENTED — the OpenBrain messages API has no mark_pending operation.
-     * This stub documents the required capability and owns the correct call site.
-     * When macmini adds mark_pending to the OpenBrain MCP, replace the body with:
-     *
-     *   String body = "{\"tool\":\"mark_pending\",\"message_id\":%d}".formatted(messageId);
-     *   POST to mcpUrl with brainKey header
-     *   return resp.statusCode() == 200;
+     * Calls the OpenBrain {@code mark_pending} MCP tool (added on macmini).
+     * On success the message is eligible for redelivery on the next poll cycle.
      *
      * Callers check the return value:
      *   true  → message is pending again; will be retried on the next poll
-     *   false → reset unavailable; caller falls through to the dead-letter path
+     *   false → reset unavailable (network error / non-200); caller falls
+     *           through to the dead-letter path
      *
-     * Feature request filed: OpenBrain thought #mark-pending-feature-request
-     * See ARCHITECTURE.md §4.3 for the failure contract this enables.
-     *
-     * @return false always (not implemented)
+     * @return true if the server accepted the reset, false otherwise
      */
     public boolean resetDelivered(int messageId) {
-        // TODO: implement when macmini adds mark_pending to the messages API
-        log.warning("resetDelivered() not implemented — message_id=" + messageId
-            + " remains 'delivered'; falling through to dead-letter path");
-        return false;
+        try {
+            String body = """
+                {"tool":"mark_pending","message_id":%d}
+                """.formatted(messageId);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(mcpUrl))
+                .timeout(TIMEOUT)
+                .header("Content-Type", "application/json")
+                .header("x-brain-key", brainKey)
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build();
+
+            HttpResponse<String> resp = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200) {
+                log.warning("resetDelivered failed for message " + messageId
+                    + ": HTTP " + resp.statusCode());
+                return false;
+            }
+            log.info("Reset message " + messageId + " to pending for retry");
+            return true;
+        } catch (Exception e) {
+            log.warning("resetDelivered failed for message " + messageId + ": " + e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/hastingtx/meshrelay/PeerConfig.java
+++ b/src/main/java/org/hastingtx/meshrelay/PeerConfig.java
@@ -53,6 +53,14 @@ public class PeerConfig {
     public final int    claudeTimeoutMinutes;
     public final int    sessionTtlMinutes;
     public final int    reaperIntervalMinutes;
+    /**
+     * Max number of messages processed concurrently across all threads.
+     * Bounds simultaneous {@code claude -p} subprocesses so a burst of work
+     * can't exhaust the machine. A single long-running task no longer blocks
+     * unrelated threads (see messenger#27); this cap keeps that concurrency
+     * from running away. Default 4.
+     */
+    public final int    maxConcurrentProcessing;
     /** Optional personality/voice for this node's agent. Null for default. */
     public final String personality;
 
@@ -60,6 +68,7 @@ public class PeerConfig {
                        String openBrainUrl, String openBrainKey, String source,
                        String processor, String claudeModel, int claudeTimeoutMinutes,
                        int sessionTtlMinutes, int reaperIntervalMinutes,
+                       int maxConcurrentProcessing,
                        String personality) {
         this.nodeName              = nodeName;
         this.listenPort            = listenPort;
@@ -72,6 +81,7 @@ public class PeerConfig {
         this.claudeTimeoutMinutes  = claudeTimeoutMinutes;
         this.sessionTtlMinutes     = sessionTtlMinutes;
         this.reaperIntervalMinutes = reaperIntervalMinutes;
+        this.maxConcurrentProcessing = maxConcurrentProcessing;
         this.personality           = personality;
     }
 
@@ -182,11 +192,12 @@ public class PeerConfig {
         int    claudeTimeoutMinutes = cfg.getInt("claude_timeout_minutes", 12);
         int    sessionTtlMinutes    = cfg.getInt("session_ttl_minutes", 240);
         int    reaperIntervalMinutes = cfg.getInt("reaper_interval_minutes", 5);
+        int    maxConcurrentProcessing = cfg.getInt("max_concurrent_processing", 4);
         String personality          = cfg.getString("personality");
 
         return new PeerConfig(nodeName, listenPort, peers, obUrl, obKey, source,
             processor, claudeModel, claudeTimeoutMinutes, sessionTtlMinutes,
-            reaperIntervalMinutes, personality);
+            reaperIntervalMinutes, maxConcurrentProcessing, personality);
     }
 
     private static void writeCache(Path cacheFile, String content) {
@@ -210,6 +221,7 @@ public class PeerConfig {
             + ", claudeModel=" + claudeModel
             + ", timeout=" + claudeTimeoutMinutes + "m"
             + ", sessionTTL=" + sessionTtlMinutes + "m"
-            + ", reaperInterval=" + reaperIntervalMinutes + "m}";
+            + ", reaperInterval=" + reaperIntervalMinutes + "m"
+            + ", maxConcurrent=" + maxConcurrentProcessing + "}";
     }
 }

--- a/src/test/java/org/hastingtx/meshrelay/MessagePollerTest.java
+++ b/src/test/java/org/hastingtx/meshrelay/MessagePollerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Timeout;
 import java.net.http.HttpClient;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.TimeUnit;
@@ -132,10 +133,12 @@ class MessagePollerTest {
      */
     static class RecordingStore extends OpenBrainStore {
         final List<PendingMessage> inbox = new ArrayList<>();
-        final List<Integer> delivered = new ArrayList<>();
-        final List<Integer> archived  = new ArrayList<>();
-        final List<Integer> watermarks = new ArrayList<>();
-        boolean drained = false;
+        // Written from processing virtual threads (messenger#27) — must be
+        // thread-safe so concurrent record + assertion reads don't corrupt.
+        final List<Integer> delivered = new CopyOnWriteArrayList<>();
+        final List<Integer> archived  = new CopyOnWriteArrayList<>();
+        final List<Integer> watermarks = new CopyOnWriteArrayList<>();
+        volatile boolean drained = false;
 
         RecordingStore(PeerConfig cfg) {
             super(HttpClient.newHttpClient(), cfg);
@@ -188,7 +191,7 @@ class MessagePollerTest {
 
     @Test
     @Timeout(10)
-    void peerBroadcastIsStillProcessedNormally() {
+    void peerBroadcastIsStillProcessedNormally() throws Exception {
         PeerConfig cfg = testConfig("linuxserver");
         RecordingStore brain = new RecordingStore(cfg);
         brain.inbox.add(new OpenBrainStore.PendingMessage(
@@ -197,6 +200,7 @@ class MessagePollerTest {
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
         poller.triggerPoll();
+        assertTrue(poller.awaitProcessingComplete(5000), "processing should drain");
 
         assertEquals(1, proc.processCount.get(),
             "peer broadcasts must still be processed");
@@ -249,7 +253,7 @@ class MessagePollerTest {
 
     @Test
     @Timeout(10)
-    void actionMessageIsProcessedNormally() {
+    void actionMessageIsProcessedNormally() throws Exception {
         // Regression guard: kind=action (the default) must still flow through processor.
         PeerConfig cfg = testConfig("linuxserver");
         RecordingStore brain = new RecordingStore(cfg);
@@ -261,6 +265,7 @@ class MessagePollerTest {
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
         poller.triggerPoll();
+        assertTrue(poller.awaitProcessingComplete(5000), "processing should drain");
 
         assertEquals(1, proc.processCount.get(),
             "action messages must go through the processor");
@@ -268,7 +273,7 @@ class MessagePollerTest {
 
     @Test
     @Timeout(10)
-    void oldMessageWithoutHeaderProcessesAsAction() {
+    void oldMessageWithoutHeaderProcessesAsAction() throws Exception {
         // Messages from pre-1.1.0 daemons don't have a version header at all.
         // Must default to action so we don't silently drop them.
         PeerConfig cfg = testConfig("linuxserver");
@@ -279,6 +284,7 @@ class MessagePollerTest {
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
         poller.triggerPoll();
+        assertTrue(poller.awaitProcessingComplete(5000), "processing should drain");
 
         assertEquals(1, proc.processCount.get(),
             "headerless messages default to action — processor must still run");
@@ -328,7 +334,7 @@ class MessagePollerTest {
 
     @Test
     @Timeout(10)
-    void mixedInboxProcessesPeerMessagesAndSkipsSelfBroadcast() {
+    void mixedInboxProcessesPeerMessagesAndSkipsSelfBroadcast() throws Exception {
         PeerConfig cfg = testConfig("linuxserver");
         RecordingStore brain = new RecordingStore(cfg);
         brain.inbox.add(new OpenBrainStore.PendingMessage(
@@ -339,6 +345,7 @@ class MessagePollerTest {
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
         poller.triggerPoll();
+        assertTrue(poller.awaitProcessingComplete(5000), "processing should drain");
 
         assertEquals(1, proc.processCount.get(),
             "only the peer direct message should reach the processor");
@@ -346,5 +353,70 @@ class MessagePollerTest {
         assertEquals(List.of(601), brain.archived);
         assertEquals(List.of(600), brain.watermarks,
             "only the skipped self-broadcast advances the watermark here");
+    }
+
+    /**
+     * Processor that blocks indefinitely for one designated thread_id (the
+     * "slow" task) and completes instantly for any other thread. Lets us prove
+     * a stuck task on one thread doesn't hold up another.
+     */
+    static class GatedProcessor implements MessageProcessor {
+        final long slowThreadId;
+        final CountDownLatch gate        = new CountDownLatch(1);
+        final CountDownLatch slowStarted = new CountDownLatch(1);
+        final AtomicInteger  fastDone    = new AtomicInteger(0);
+
+        GatedProcessor(long slowThreadId) { this.slowThreadId = slowThreadId; }
+
+        @Override
+        public void process(OpenBrainStore.PendingMessage m) throws Exception {
+            if (m.threadId() == slowThreadId) {
+                slowStarted.countDown();
+                gate.await();              // simulate a long-running agent
+            } else {
+                fastDone.incrementAndGet(); // a quick task on another thread
+            }
+        }
+    }
+
+    /**
+     * Core regression for messenger#27: a long-running task on one thread must
+     * NOT block an unrelated short task on a different thread. This is exactly
+     * the thread 811 (FATS project) vs thread 812 (limerick) scenario.
+     */
+    @Test
+    @Timeout(15)
+    void longTaskOnOneThreadDoesNotBlockAnotherThread() throws Exception {
+        PeerConfig cfg = testConfig("linuxserver");
+        RecordingStore brain = new RecordingStore(cfg);
+        String slow = RelayHandler.stampVersionHeader("long project kickoff", "macmini", "1.1.3", "action");
+        String fast = RelayHandler.stampVersionHeader("quick limerick please", "macmini", "1.1.3", "action");
+        brain.inbox.add(new OpenBrainStore.PendingMessage(811, 811L, "macmini", "linuxserver", slow, "pending"));
+        brain.inbox.add(new OpenBrainStore.PendingMessage(812, 812L, "macmini", "linuxserver", fast, "pending"));
+
+        GatedProcessor proc = new GatedProcessor(811L);
+        MessagePoller poller = new MessagePoller(cfg, brain, proc);
+        poller.triggerPoll();
+
+        assertTrue(proc.slowStarted.await(5, TimeUnit.SECONDS),
+            "the slow task (thread 811) should have started");
+
+        // While 811 is wedged, the fast task on thread 812 must still complete.
+        long deadline = System.nanoTime() + 5_000_000_000L;
+        while (proc.fastDone.get() == 0 && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        assertEquals(1, proc.fastDone.get(),
+            "thread 812 must complete while thread 811 is still blocked (messenger#27)");
+        assertTrue(brain.archived.contains(812),
+            "the fast message should be archived even though the slow one is stuck");
+        assertFalse(brain.archived.contains(811),
+            "the slow message must NOT be archived yet — it's still blocked");
+
+        // Release the slow task and confirm everything drains.
+        proc.gate.countDown();
+        assertTrue(poller.awaitProcessingComplete(5000), "all processing should drain");
+        assertTrue(brain.archived.contains(811),
+            "the slow message archives once it finally finishes");
     }
 }


### PR DESCRIPTION
Closes #27.

## Problem (evidence: thread 812)
`MessagePoller.poll()` processed each pending message **inline on the single poller thread**, blocking on the `claude -p` subprocess for up to the full timeout (12m). Thread **811** (the FATS project kickoff — a huge long-running agent) monopolized the processor, so the poll loop never advanced: `last_poll` froze and an unrelated connectivity test (thread **812**, "reply with a limerick") sat `pending` while `messages_processed` stayed `0`.

The class Javadoc claimed cross-thread concurrency, but the implementation ran everything serially.

## Changes
1. **Decouple processing from polling (primary).** `poll()` now claims each message into an in-flight set and dispatches it to a background virtual thread, returning immediately. Different threads process concurrently; same-thread ordering is preserved by a now-**fair** per-thread lock. Total concurrency is bounded by a new configurable semaphore `max_concurrent_processing` (default 4) so a burst can't exhaust the machine.
2. **Concurrency-safe counters.** `totalProcessed` → `AtomicInteger`, `lastPollTime` → `volatile` (now touched by multiple threads).
3. **`resetDelivered()` implemented** via the now-available `mark_pending` MCP tool — a timed-out/failed message returns to `pending` for retry instead of being silently dead-lettered.
4. **`/ping` fix.** Daemon now serves JSON (was bare `pong`); the Python `msg_ping` client is also made tolerant. Fixes the `Expecting value: line 1 column 1` liveness-probe error.

## Tests
New regression `longTaskOnOneThreadDoesNotBlockAnotherThread` reproduces the 811-vs-812 scenario: a blocked task on one thread no longer delays a short task on another. Full suite: **211 passed**.

## Version
Bumped to **1.2.1** (the deployed daemon reports 1.2.0 from an uncommitted build; committed `main` pom lagged at 1.1.6).

## Not included / follow-up
- **Deploy is not done in this PR.** Restarting the live daemon will SIGKILL the still-running FATS agent (thread 811). Hold for explicit go-ahead.
- Routing 6-month "project" workloads through the synchronous relay (12m timeout) is a category error worth a separate issue — those should run detached, not on the relay path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)