### PR TITLE
Fix #27 (part 1): resetDelivered + JSON /ping (v1.2.1)

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -86,7 +86,16 @@ def msg_health() -> dict:
 @mcp.tool()
 def msg_ping() -> dict:
     """Quick liveness check — is the local messenger daemon running?"""
-    return _get("/ping")
+    # Older daemons answer /ping with bare text "pong" (not JSON). Tolerate both
+    # so a version skew between the MCP wrapper and the daemon can't break the
+    # liveness probe. See messenger#27.
+    with httpx.Client(timeout=10) as client:
+        r = client.get(f"{MESSENGER_URL}/ping")
+        r.raise_for_status()
+        try:
+            return r.json()
+        except ValueError:
+            return {"status": "ok", "response": r.text.strip()}
 
 
 # --- Ask User (via Telegram) ---

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hastingtx</groupId>
     <artifactId>messenger</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
     <description>Reliable agent-to-agent messaging daemon. Stores full messages in OpenBrain, delivers wake-up pings, polls every 10 minutes as catchup. Zero external dependencies.</description>
 

--- a/src/main/java/org/hastingtx/meshrelay/MeshRelay.java
+++ b/src/main/java/org/hastingtx/meshrelay/MeshRelay.java
@@ -179,7 +179,12 @@ public class MeshRelay {
         server.createContext("/wake",      new WakeHandler(config, poller));
         server.createContext("/health",    new HealthHandler(config, poller, java.time.Instant.now(), processor));
         server.createContext("/ping", exchange -> {
-            byte[] pong = "pong".getBytes(StandardCharsets.UTF_8);
+            // Return JSON (not bare "pong") so JSON-only clients like the Python
+            // MCP wrapper's msg_ping can parse the response. See messenger#27.
+            byte[] pong = ("{\"status\":\"ok\",\"node\":\"" + config.nodeName
+                + "\",\"version\":\"" + Version.VERSION + "\",\"response\":\"pong\"}")
+                .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
             exchange.sendResponseHeaders(200, pong.length);
             exchange.getResponseBody().write(pong);
             exchange.close();

--- a/src/main/java/org/hastingtx/meshrelay/OpenBrainStore.java
+++ b/src/main/java/org/hastingtx/meshrelay/OpenBrainStore.java
@@ -226,28 +226,43 @@ public class OpenBrainStore {
     /**
      * Reset a "delivered" message back to "pending" for retry.
      *
-     * NOT IMPLEMENTED — the OpenBrain messages API has no mark_pending operation.
-     * This stub documents the required capability and owns the correct call site.
-     * When macmini adds mark_pending to the OpenBrain MCP, replace the body with:
-     *
-     *   String body = "{\"tool\":\"mark_pending\",\"message_id\":%d}".formatted(messageId);
-     *   POST to mcpUrl with brainKey header
-     *   return resp.statusCode() == 200;
+     * Calls the OpenBrain {@code mark_pending} MCP tool (added on macmini).
+     * On success the message is eligible for redelivery on the next poll cycle,
+     * instead of being silently dead-lettered after a processing failure.
      *
      * Callers check the return value:
      *   true  → message is pending again; will be retried on the next poll
-     *   false → reset unavailable; caller falls through to the dead-letter path
+     *   false → reset unavailable (network error / non-200); caller falls
+     *           through to the dead-letter path
      *
-     * Feature request filed: OpenBrain thought #mark-pending-feature-request
-     * See ARCHITECTURE.md §4.3 for the failure contract this enables.
-     *
-     * @return false always (not implemented)
+     * @return true if the server accepted the reset, false otherwise
      */
     public boolean resetDelivered(int messageId) {
-        // TODO: implement when macmini adds mark_pending to the messages API
-        log.warning("resetDelivered() not implemented — message_id=" + messageId
-            + " remains 'delivered'; falling through to dead-letter path");
-        return false;
+        try {
+            String body = """
+                {"tool":"mark_pending","message_id":%d}
+                """.formatted(messageId);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(mcpUrl))
+                .timeout(TIMEOUT)
+                .header("Content-Type", "application/json")
+                .header("x-brain-key", brainKey)
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build();
+
+            HttpResponse<String> resp = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200) {
+                log.warning("resetDelivered failed for message " + messageId
+                    + ": HTTP " + resp.statusCode());
+                return false;
+            }
+            log.info("Reset message " + messageId + " to pending for retry");
+            return true;
+        } catch (Exception e) {
+            log.warning("resetDelivered failed for message " + messageId + ": " + e.getMessage());
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Part 1 of #27 — the two **isolated, low-risk** fixes, split out so they can ship without touching the freshly-deployed v1.2.0 concurrency path.

## Changes
- **`OpenBrainStore.resetDelivered()`** — was a stub returning `false`, so every processing failure fell straight to dead-letter. This is exactly how the timed-out FATS kickoff (thread 811) was silently dropped. Now calls the `mark_pending` MCP tool so a failed/timed-out message returns to `pending` for retry.
- **`/ping`** — daemon served bare text `pong`; the Python `msg_ping` client called `r.json()` → `Expecting value: line 1 column 1`. Now serves JSON, and the client tolerates either form (survives daemon/wrapper version skew).
- Version → **1.2.1**.

## Testing
Full suite: **358 passed**.

## Deferred to part 2
The primary async-dispatch fix (#27 fix #1) is **not** here. It rewrites the v1.2.0 poll concurrency model and must be reconciled with the dedup cache + MAX_TURNS counter (a duplicate arriving mid-processing would otherwise miss the cache) and ~13 synchronous tests reworked. That lands as a separate PR rebased on v1.2.0, reviewed before it touches the live mesh. Supersedes the stale-base PR #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)