### PR TITLE
Fix #27 (part 2): async per-thread dispatch — end head-of-line blocking (v1.3.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hastingtx</groupId>
     <artifactId>messenger</artifactId>
-    <version>1.2.2</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
     <description>Reliable agent-to-agent messaging daemon. Stores full messages in OpenBrain, delivers wake-up pings, polls every 10 minutes as catchup. Zero external dependencies.</description>
 

--- a/src/main/java/org/hastingtx/meshrelay/MessagePoller.java
+++ b/src/main/java/org/hastingtx/meshrelay/MessagePoller.java
@@ -5,11 +5,14 @@ import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 
 /**
@@ -27,12 +30,24 @@ import java.util.logging.Logger;
  *      after the current one completes. N simultaneous wake-ups collapse
  *      into at most 2 sequential runs — no double-processing.
  *
- *   2. Per-thread serialization:
+ *   2. Per-thread serialization with cross-thread concurrency:
  *      Messages belonging to the same conversation thread (same thread_id)
- *      are processed one at a time, in arrival order. This ensures an agent
- *      processing reply B always sees reply A fully committed first.
- *      Different threads are processed concurrently with no ordering
- *      constraint between them.
+ *      are processed one at a time, in arrival order, via a per-thread serial
+ *      task chain. This ensures an agent processing reply B always sees reply
+ *      A fully committed first. Different threads process concurrently on
+ *      background virtual threads, so a long-running task on one thread never
+ *      blocks another thread — or the poll loop itself. This is the fix for
+ *      messenger#27, where a multi-minute project agent on one thread left an
+ *      unrelated connectivity test (thread 812) stuck pending for the full
+ *      claude timeout. Total concurrency is bounded by a semaphore
+ *      (config.maxConcurrentProcessing) so a burst can't exhaust the machine.
+ *
+ *   3. Non-blocking dispatch:
+ *      poll() runs the cheap synchronous filters (status, dedup, MAX_TURNS,
+ *      kind, suppression, rate limit) inline, then hands the expensive
+ *      processor call to the per-thread chain and returns immediately. An
+ *      in-flight set keyed by message_id prevents an overlapping poll from
+ *      re-dispatching a message before it has been marked delivered.
  */
 public class MessagePoller implements Runnable {
 
@@ -65,13 +80,13 @@ public class MessagePoller implements Runnable {
     private final DedupCache       dedupCache;
 
     private volatile boolean running  = true;
-    private Instant lastPollTime      = Instant.EPOCH;
-    private int     totalProcessed    = 0;
+    // lastPollTime is written by the poll loop and read by the health endpoint;
+    // totalProcessed is incremented from many processing virtual threads
+    // (messenger#27) — both must be safe for cross-thread visibility.
+    private volatile Instant lastPollTime = Instant.EPOCH;
+    private final AtomicInteger totalProcessed = new AtomicInteger(0);
 
     // ── Concurrency controls ──────────────────────────────────────────────
-
-    /** How long to wait for a per-thread lock before giving up on this message. */
-    private static final long THREAD_LOCK_TIMEOUT_MINUTES = 12;
 
     /** True while a poll() run is executing. */
     private final AtomicBoolean pollInFlight = new AtomicBoolean(false);
@@ -84,11 +99,33 @@ public class MessagePoller implements Runnable {
     private final AtomicBoolean pollPending = new AtomicBoolean(false);
 
     /**
-     * Per-thread locks: ensures messages with the same thread_id are processed
-     * sequentially. Locks are created on demand and removed after use to avoid
-     * unbounded map growth.
+     * Per-thread serial task chains: each thread_id maps to the tail of a
+     * CompletableFuture chain. A new message for a thread is appended after the
+     * current tail, so same-thread messages run strictly in arrival order while
+     * different threads run concurrently on {@link #processingPool}. Entries are
+     * pruned when their chain drains (see {@link #dispatch}).
      */
-    private final ConcurrentHashMap<Long, ReentrantLock> threadLocks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, CompletableFuture<Void>> threadChains = new ConcurrentHashMap<>();
+
+    /**
+     * Message ids currently dispatched to a chain (claimed but not yet finished).
+     * Guards against an overlapping poll re-dispatching a message in the window
+     * before markDelivered() lands. Entries are removed when processing finishes
+     * (success, failure, or dead-letter).
+     */
+    private final Set<Integer> inFlight = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Bounds the number of messages processed concurrently across all threads.
+     * Each permit gates one {@code claude -p} subprocess. Sized from
+     * config.maxConcurrentProcessing; fair so a task that queued earlier isn't
+     * starved behind later ones.
+     */
+    private final Semaphore processingSlots;
+
+    /** Virtual-thread pool that runs the per-thread chain stages. */
+    private final ExecutorService processingPool =
+        Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("msg-proc-", 0).factory());
 
     /**
      * Per-thread non-progress message counter for the {@link #MAX_TURNS_PER_THREAD}
@@ -124,6 +161,7 @@ public class MessagePoller implements Runnable {
         this.processor   = processor;
         this.relaySender = relaySender != null ? relaySender : RelaySender.NOOP;
         this.dedupCache  = dedupCache  != null ? dedupCache  : new DedupCache();
+        this.processingSlots = new Semaphore(Math.max(1, config.maxConcurrentProcessing), true);
     }
 
     /**
@@ -365,8 +403,52 @@ public class MessagePoller implements Runnable {
                 brain.markArchived(msg.messageId());
                 continue;
             }
-            processWithThreadLock(msg);
+            dispatch(msg);
         }
+    }
+
+    /**
+     * Hand a message off to its thread's serial chain for processing, then
+     * return immediately so the poll loop is never blocked by a slow task.
+     *
+     * The in-flight set is the dedup guard: if this message id is already being
+     * processed (e.g. an overlapping poll saw it before markDelivered landed),
+     * skip the duplicate dispatch. Same-thread ordering is guaranteed by
+     * appending to the thread's CompletableFuture chain; the global concurrency
+     * cap is enforced inside {@link #processClaimed} via the processing semaphore.
+     */
+    private void dispatch(OpenBrainStore.PendingMessage msg) {
+        if (!inFlight.add(msg.messageId())) {
+            log.fine("Already in-flight — skipping duplicate dispatch message_id="
+                + msg.messageId() + " thread_id=" + msg.threadId());
+            return;
+        }
+        long threadId = msg.threadId();
+        threadChains.compute(threadId, (tid, prev) -> {
+            // Chain after the current tail (or start fresh if the thread is idle).
+            // handle((r,e)->null) so a failed predecessor never breaks the successor.
+            CompletableFuture<Void> base = (prev == null || prev.isDone())
+                ? CompletableFuture.completedFuture(null)
+                : prev;
+            CompletableFuture<Void> next = base
+                .handle((r, e) -> null)
+                .thenRunAsync(() -> {
+                    try {
+                        processClaimed(msg);
+                    } catch (Throwable t) {
+                        // processClaimed handles its own exceptions; last-resort guard.
+                        log.warning("Unexpected error processing message_id=" + msg.messageId()
+                            + " thread_id=" + threadId + ": " + t);
+                    } finally {
+                        inFlight.remove(msg.messageId());
+                    }
+                }, processingPool);
+            // Prune the map entry once this chain drains, unless a later message
+            // has already extended it (then the map holds the newer tail).
+            next.whenComplete((r, e) ->
+                threadChains.computeIfPresent(threadId, (k, tail) -> tail == next ? null : tail));
+            return next;
+        });
     }
 
     /**
@@ -509,98 +591,96 @@ public class MessagePoller implements Runnable {
      * Messages with different thread_ids run concurrently.
      * Messages with the same thread_id are serialized.
      */
-    private void processWithThreadLock(OpenBrainStore.PendingMessage msg) {
+    private void processClaimed(OpenBrainStore.PendingMessage msg) {
         long threadId = msg.threadId();
-        ReentrantLock lock = threadLocks.computeIfAbsent(threadId, id -> new ReentrantLock());
-        boolean acquired;
-        try {
-            acquired = lock.tryLock(THREAD_LOCK_TIMEOUT_MINUTES, TimeUnit.MINUTES);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.warning("Interrupted waiting for thread lock thread_id=" + threadId
-                + " — skipping, will retry next poll");
-            return;
-        }
 
-        if (!acquired) {
-            // The previous message in this thread has been running for 15+ minutes.
-            // Leave this message unarchived so it will be retried next poll.
-            log.warning("Thread lock timeout (>" + THREAD_LOCK_TIMEOUT_MINUTES + "m) for thread_id="
-                + threadId + " from=" + msg.fromNode()
-                + " — skipping this cycle, will retry next poll");
+        // Claim the message before processing to prevent duplicate delivery.
+        // markDelivered (pending → delivered) is the atomic claim step — once
+        // claimed, subsequent polls won't see this message even if archiving
+        // later fails. If OpenBrain is unavailable here, skip and retry next poll.
+        if (!brain.markDelivered(msg.messageId())) {
+            log.warning("Could not mark message delivered thread_id=" + threadId
+                + " messageId=" + msg.messageId() + " — skipping, will retry next poll");
             return;
         }
 
         try {
-            // Claim the message before processing to prevent duplicate delivery.
-            // If OpenBrain is unavailable here, skip and retry next poll (still "active").
-            // Once claimed, subsequent polls won't see this message even if archiving later fails.
-            // Mark delivered (pending → delivered) before processing.
-            // This is the atomic "claim" step — prevents duplicate delivery if
-            // the poll runs again before we finish.
-            //
-            // NOTE: unlike the old claimMessage/resetMessage pair, the messages
-            // table has no "reset to pending" operation. If processing fails after
-            // markDelivered(), the message stays in "delivered" state and will NOT
-            // be retried by the normal poll path. Manual recovery would be needed.
-            if (!brain.markDelivered(msg.messageId())) {
-                log.warning("Could not mark message delivered thread_id=" + threadId
-                    + " messageId=" + msg.messageId() + " — skipping, will retry next poll");
-                return;
-            }
-
+            // Bound concurrent claude subprocesses across all threads. Acquired
+            // only around the expensive processor call, not the cheap OpenBrain
+            // bookkeeping, so permits free up promptly.
+            processingSlots.acquire();
             try {
                 processor.process(msg);
-                brain.markArchived(msg.messageId());
-                if ("all".equals(msg.toNode())) {
-                    brain.updateBroadcastWatermark(config.nodeName, msg.messageId());
-                }
-                // v1.2 dedup cache (issue #16): record at minimum the
-                // "processed-no-response" sentinel for this key. Processors
-                // that emit an outbound reply (ClaudeCliProcessor,
-                // GemmaProcessor) overwrite the sentinel with the real
-                // response via dedupCache().put(...) once sendReply succeeds —
-                // see those classes. Sentinel placement here covers the
-                // processor-returned-no-output / no-reply paths so a
-                // duplicate is silently swallowed instead of re-running the
-                // processor.
-                String seqId = RelayHandler.extractHeaderField(msg.content(), "seq", null);
-                if (seqId != null && !seqId.isBlank()) {
-                    DedupCache.DedupKey key = new DedupCache.DedupKey(
-                        msg.fromNode(), msg.threadId(), seqId);
-                    if (!dedupCache.contains(key)) dedupCache.putSentinel(key);
-                }
-                recordProcessed(msg.fromNode());
-                totalProcessed++;
-                log.info("Processed message thread_id=" + threadId
-                    + " from=" + msg.fromNode()
-                    + " total_processed=" + totalProcessed);
-            } catch (Exception e) {
-                log.warning("Failed to process message thread_id=" + threadId
-                    + " messageId=" + msg.messageId() + ": " + e.getMessage());
-                // Attempt to reset to pending so the message can be retried.
-                // resetDelivered() is a stub — always returns false until macmini
-                // adds mark_pending to the OpenBrain MCP API (see OpenBrainStore).
-                if (!brain.resetDelivered(msg.messageId())) {
-                    // Reset unavailable — dead-letter: archive to clear "delivered"
-                    // limbo, then log to OpenBrain for auditability.
-                    log.warning("Reset unavailable — archiving as dead-letter:"
-                        + " thread_id=" + threadId + " messageId=" + msg.messageId());
-                    brain.markArchived(msg.messageId());
-                    brain.storeDeadLetter(msg, e.getMessage());
-                }
-                // If reset succeeded, message returns to pending and will be
-                // retried on the next poll cycle.
+            } finally {
+                processingSlots.release();
             }
-        } finally {
-            lock.unlock();
-            // Remove lock if no other thread is waiting on it
-            threadLocks.remove(threadId, lock);
+            brain.markArchived(msg.messageId());
+            if ("all".equals(msg.toNode())) {
+                brain.updateBroadcastWatermark(config.nodeName, msg.messageId());
+            }
+            // v1.2 dedup cache (issue #16): record at minimum the
+            // "processed-no-response" sentinel for this key. Processors
+            // that emit an outbound reply (ClaudeCliProcessor, GemmaProcessor)
+            // overwrite the sentinel with the real response via
+            // dedupCache().put(...) once sendReply succeeds — see those classes.
+            // Sentinel placement here covers the processor-returned-no-output /
+            // no-reply paths so a duplicate is silently swallowed instead of
+            // re-running the processor.
+            String seqId = RelayHandler.extractHeaderField(msg.content(), "seq", null);
+            if (seqId != null && !seqId.isBlank()) {
+                DedupCache.DedupKey key = new DedupCache.DedupKey(
+                    msg.fromNode(), msg.threadId(), seqId);
+                if (!dedupCache.contains(key)) dedupCache.putSentinel(key);
+            }
+            recordProcessed(msg.fromNode());
+            int processed = totalProcessed.incrementAndGet();
+            log.info("Processed message thread_id=" + threadId
+                + " from=" + msg.fromNode()
+                + " total_processed=" + processed);
+        } catch (Exception e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+            log.warning("Failed to process message thread_id=" + threadId
+                + " messageId=" + msg.messageId() + ": " + e.getMessage());
+            // Return the message to pending so it can be retried (resetDelivered
+            // calls mark_pending). Only if that reset is unavailable do we
+            // dead-letter: archive to clear the "delivered" limbo, then log to
+            // OpenBrain for auditability.
+            if (!brain.resetDelivered(msg.messageId())) {
+                log.warning("Reset unavailable — archiving as dead-letter:"
+                    + " thread_id=" + threadId + " messageId=" + msg.messageId());
+                brain.markArchived(msg.messageId());
+                brain.storeDeadLetter(msg, e.getMessage());
+            }
+            // If reset succeeded, message returns to pending and will be
+            // retried on the next poll cycle.
         }
     }
 
-    public void stop() { running = false; }
+    public void stop() {
+        running = false;
+        processingPool.shutdown();
+    }
 
     public Instant getLastPollTime()   { return lastPollTime; }
-    public int     getTotalProcessed() { return totalProcessed; }
+    public int     getTotalProcessed() { return totalProcessed.get(); }
+
+    /** Number of messages currently dispatched but not yet finished processing. */
+    int inFlightCount() { return inFlight.size(); }
+
+    /**
+     * Block until all dispatched messages have finished processing, or the
+     * timeout elapses. Processing runs on background virtual threads
+     * (messenger#27), so callers that need to observe the terminal state —
+     * tests, graceful shutdown — use this to await quiescence.
+     *
+     * @return true if processing drained within the timeout, false otherwise
+     */
+    boolean awaitProcessingComplete(long timeoutMillis) throws InterruptedException {
+        long deadline = System.nanoTime() + timeoutMillis * 1_000_000L;
+        while (!inFlight.isEmpty()) {
+            if (System.nanoTime() >= deadline) return false;
+            Thread.sleep(10);
+        }
+        return true;
+    }
 }

--- a/src/main/java/org/hastingtx/meshrelay/PeerConfig.java
+++ b/src/main/java/org/hastingtx/meshrelay/PeerConfig.java
@@ -53,6 +53,13 @@ public class PeerConfig {
     public final int    claudeTimeoutMinutes;
     public final int    sessionTtlMinutes;
     public final int    reaperIntervalMinutes;
+    /**
+     * Max messages processed concurrently across all threads. Bounds the number
+     * of simultaneous {@code claude -p} subprocesses so a burst can't exhaust the
+     * machine. Different conversation threads process concurrently (messenger#27);
+     * this caps that concurrency. Default 4.
+     */
+    public final int    maxConcurrentProcessing;
     /** Optional personality/voice for this node's agent. Null for default. */
     public final String personality;
 
@@ -60,6 +67,7 @@ public class PeerConfig {
                        String openBrainUrl, String openBrainKey, String source,
                        String processor, String claudeModel, int claudeTimeoutMinutes,
                        int sessionTtlMinutes, int reaperIntervalMinutes,
+                       int maxConcurrentProcessing,
                        String personality) {
         this.nodeName              = nodeName;
         this.listenPort            = listenPort;
@@ -72,6 +80,7 @@ public class PeerConfig {
         this.claudeTimeoutMinutes  = claudeTimeoutMinutes;
         this.sessionTtlMinutes     = sessionTtlMinutes;
         this.reaperIntervalMinutes = reaperIntervalMinutes;
+        this.maxConcurrentProcessing = maxConcurrentProcessing;
         this.personality           = personality;
     }
 
@@ -182,11 +191,12 @@ public class PeerConfig {
         int    claudeTimeoutMinutes = cfg.getInt("claude_timeout_minutes", 12);
         int    sessionTtlMinutes    = cfg.getInt("session_ttl_minutes", 240);
         int    reaperIntervalMinutes = cfg.getInt("reaper_interval_minutes", 5);
+        int    maxConcurrentProcessing = cfg.getInt("max_concurrent_processing", 4);
         String personality          = cfg.getString("personality");
 
         return new PeerConfig(nodeName, listenPort, peers, obUrl, obKey, source,
             processor, claudeModel, claudeTimeoutMinutes, sessionTtlMinutes,
-            reaperIntervalMinutes, personality);
+            reaperIntervalMinutes, maxConcurrentProcessing, personality);
     }
 
     private static void writeCache(Path cacheFile, String content) {
@@ -210,6 +220,7 @@ public class PeerConfig {
             + ", claudeModel=" + claudeModel
             + ", timeout=" + claudeTimeoutMinutes + "m"
             + ", sessionTTL=" + sessionTtlMinutes + "m"
-            + ", reaperInterval=" + reaperIntervalMinutes + "m}";
+            + ", reaperInterval=" + reaperIntervalMinutes + "m"
+            + ", maxConcurrent=" + maxConcurrentProcessing + "}";
     }
 }

--- a/src/test/java/org/hastingtx/meshrelay/BackCompatTest.java
+++ b/src/test/java/org/hastingtx/meshrelay/BackCompatTest.java
@@ -90,6 +90,24 @@ class BackCompatTest {
             node, "http://brain", "k", "test");
     }
 
+    /**
+     * Poll and wait for any dispatched processing to drain. Processing runs on
+     * background virtual threads (messenger#27), so assertions on processCount
+     * must wait for quiescence. No-op for skip-path messages.
+     */
+    private static void pump(MessagePoller poller) {
+        poller.triggerPoll();
+        long deadline = System.currentTimeMillis() + 5000;
+        try {
+            while (poller.inFlightCount() > 0 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(10);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        assertEquals(0, poller.inFlightCount(), "processing should drain within timeout");
+    }
+
     // ════════════════════════════════════════════════════════════════════════
     // A. Pre-v1.2 sender → v1.2 receiver
     //    (no new fields on the wire; receiver fills in spec defaults)
@@ -148,7 +166,7 @@ class BackCompatTest {
             500, 500L, "macbook-air", "linuxserver", content, "pending"));
 
         CountingProcessor proc = new CountingProcessor();
-        new MessagePoller(cfg, brain, proc).triggerPoll();
+        pump(new MessagePoller(cfg, brain, proc));
 
         assertEquals(1, proc.processCount.get(),
             "pre-v1.2 action message must run processor unchanged");
@@ -165,7 +183,7 @@ class BackCompatTest {
             501, 501L, "macbook-air", "linuxserver", "plain legacy body", "pending"));
 
         CountingProcessor proc = new CountingProcessor();
-        new MessagePoller(cfg, brain, proc).triggerPoll();
+        pump(new MessagePoller(cfg, brain, proc));
 
         assertEquals(1, proc.processCount.get(),
             "headerless legacy message must fall back to kind=action");
@@ -184,7 +202,7 @@ class BackCompatTest {
             502, 502L, "macbook-air", "linuxserver", content, "pending"));
 
         CountingProcessor proc = new CountingProcessor();
-        new MessagePoller(cfg, brain, proc).triggerPoll();
+        pump(new MessagePoller(cfg, brain, proc));
 
         assertEquals(0, proc.processCount.get(),
             "pre-v1.2 ack must not reach processor");
@@ -281,7 +299,7 @@ class BackCompatTest {
             600, 600L, "linuxserver", "macbook-air", content, "pending"));
 
         CountingProcessor proc = new CountingProcessor();
-        new MessagePoller(cfg, brain, proc).triggerPoll();
+        pump(new MessagePoller(cfg, brain, proc));
 
         assertEquals(1, proc.processCount.get(),
             "v1.2 → mocked v1.1.6: action must dispatch");
@@ -302,7 +320,7 @@ class BackCompatTest {
             601, 601L, "macbook-air", "linuxserver", content, "pending"));
 
         CountingProcessor proc = new CountingProcessor();
-        new MessagePoller(cfg, brain, proc).triggerPoll();
+        pump(new MessagePoller(cfg, brain, proc));
 
         assertEquals(1, proc.processCount.get(),
             "mocked v1.1.6 → v1.2: action must run processor with defaults");
@@ -325,7 +343,7 @@ class BackCompatTest {
             602, 602L, "macbook-air", "linuxserver", content, "pending"));
 
         CountingProcessor proc = new CountingProcessor();
-        new MessagePoller(cfg, brain, proc).triggerPoll();
+        pump(new MessagePoller(cfg, brain, proc));
 
         assertEquals(1, proc.processCount.get(),
             "fully stamped v1.2 action must dispatch normally");
@@ -350,7 +368,7 @@ class BackCompatTest {
             603, 603L, "macbook-air", "linuxserver", content, "pending"));
 
         CountingProcessor proc = new CountingProcessor();
-        new MessagePoller(cfg, brain, proc).triggerPoll();
+        pump(new MessagePoller(cfg, brain, proc));
 
         assertEquals(0, proc.processCount.get(),
             "NO_REPLY action must NEVER reach the processor");

--- a/src/test/java/org/hastingtx/meshrelay/MessagePollerTest.java
+++ b/src/test/java/org/hastingtx/meshrelay/MessagePollerTest.java
@@ -7,6 +7,7 @@ import java.net.http.HttpClient;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.TimeUnit;
@@ -133,10 +134,12 @@ class MessagePollerTest {
      */
     static class RecordingStore extends OpenBrainStore {
         final List<PendingMessage> inbox = new ArrayList<>();
-        final List<Integer> delivered = new ArrayList<>();
-        final List<Integer> archived  = new ArrayList<>();
-        final List<Integer> watermarks = new ArrayList<>();
-        boolean drained = false;
+        // Written from processing virtual threads (messenger#27) — thread-safe
+        // so concurrent record + assertion reads don't corrupt.
+        final List<Integer> delivered = new CopyOnWriteArrayList<>();
+        final List<Integer> archived  = new CopyOnWriteArrayList<>();
+        final List<Integer> watermarks = new CopyOnWriteArrayList<>();
+        volatile boolean drained = false;
 
         RecordingStore(PeerConfig cfg) {
             super(HttpClient.newHttpClient(), cfg);
@@ -165,6 +168,25 @@ class MessagePollerTest {
             nodeName, "http://brain", "k", "test");
     }
 
+    /**
+     * Trigger a poll and wait for any dispatched processing to drain. Processing
+     * now runs on background virtual threads (messenger#27), so a test that
+     * asserts on processCount/delivered/archived must wait for quiescence. A
+     * no-op for skip-path messages (nothing dispatched → inFlightCount already 0).
+     */
+    private static void pump(MessagePoller poller) {
+        poller.triggerPoll();
+        long deadline = System.currentTimeMillis() + 5000;
+        try {
+            while (poller.inFlightCount() > 0 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(10);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        assertEquals(0, poller.inFlightCount(), "processing should drain within timeout");
+    }
+
     @Test
     @Timeout(10)
     void selfBroadcastIsSkippedAndWatermarkAdvances() {
@@ -175,7 +197,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get(),
             "processor must not run for self-broadcasts — prevents dead-letter loop");
@@ -197,7 +219,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(1, proc.processCount.get(),
             "peer broadcasts must still be processed");
@@ -219,7 +241,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get(),
             "ack messages must NOT reach the processor (prevents reply-to-ack cascade)");
@@ -242,7 +264,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get());
         assertEquals(List.of(701), brain.archived);
@@ -261,7 +283,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(1, proc.processCount.get(),
             "action messages must go through the processor");
@@ -279,7 +301,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(1, proc.processCount.get(),
             "headerless messages default to action — processor must still run");
@@ -298,7 +320,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get(),
             "archived messages must not reach the processor");
@@ -320,7 +342,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get(),
             "in-flight (delivered) messages must not be double-processed");
@@ -344,7 +366,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get(),
             "reply messages must not reach the processor");
@@ -364,7 +386,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get(),
             "progress beats must never run the processor");
@@ -388,7 +410,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get(),
             "ping must not run Claude — daemon handles it directly");
@@ -509,7 +531,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get(),
             "NO_REPLY inbound must not invoke the processor");
@@ -534,7 +556,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(0, proc.processCount.get());
         assertEquals(List.of(1001), brain.archived);
@@ -579,7 +601,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(2, proc.processCount.get(),
             "exactly the 2 actions must reach the processor — no auto-loop, "
@@ -621,7 +643,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(MessagePoller.MAX_TURNS_PER_THREAD, proc.processCount.get(),
             "exactly MAX_TURNS_PER_THREAD (=20) actions must process; the 21st is dropped");
@@ -649,7 +671,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         // First 20 process; messages 21..25 (5 of them) are dropped.
         assertEquals(20, proc.processCount.get());
@@ -696,7 +718,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(20, proc.processCount.get(),
             "20 actions must process — progress beats don't count toward the cap");
@@ -766,7 +788,7 @@ class MessagePollerTest {
         // First poll: process the message, cache populated with real response.
         brain.inbox.add(new OpenBrainStore.PendingMessage(
             6000, 42L, "macmini", "linuxserver", content, "pending"));
-        poller.triggerPoll();
+        pump(poller);
         assertEquals(1, proc.processCount.get(),
             "first inbound must reach the processor");
 
@@ -776,7 +798,7 @@ class MessagePollerTest {
         brain.inbox.clear();
         brain.inbox.add(new OpenBrainStore.PendingMessage(
             6001, 42L, "macmini", "linuxserver", content, "pending"));
-        poller.triggerPoll();
+        pump(poller);
 
         // Acceptance: processor called exactly once across both polls.
         assertEquals(1, proc.processCount.get(),
@@ -822,7 +844,7 @@ class MessagePollerTest {
             6101, 42L, "macmini", "linuxserver",
             stampAction("second turn", "macmini", "macmini:42:2"), "pending"));
 
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(2, proc.processCount.get(),
             "distinct seq_ids on the same thread must both reach the processor");
@@ -850,7 +872,7 @@ class MessagePollerTest {
 
         brain.inbox.add(new OpenBrainStore.PendingMessage(
             6200, 99L, "macmini", "linuxserver", content, "pending"));
-        poller.triggerPoll();
+        pump(poller);
         assertEquals(1, proc.processCount.get());
 
         // Sentinel must now be present (set by MessagePoller post-success).
@@ -865,7 +887,7 @@ class MessagePollerTest {
         brain.inbox.clear();
         brain.inbox.add(new OpenBrainStore.PendingMessage(
             6201, 99L, "macmini", "linuxserver", content, "pending"));
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(1, proc.processCount.get(),
             "duplicate must NOT re-invoke the processor");
@@ -893,14 +915,14 @@ class MessagePollerTest {
 
         brain.inbox.add(new OpenBrainStore.PendingMessage(
             6300, 33L, "macmini", "linuxserver", content, "pending"));
-        poller.triggerPoll();
+        pump(poller);
         assertEquals(1, proc.processCount.get());
 
         brain.drained = false;
         brain.inbox.clear();
         brain.inbox.add(new OpenBrainStore.PendingMessage(
             6301, 33L, "macmini", "linuxserver", content, "pending"));
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(2, proc.processCount.get(),
             "no seq_id ⇒ no dedup key ⇒ both copies must be processed");
@@ -927,7 +949,7 @@ class MessagePollerTest {
         // First poll: process once.
         brain.inbox.add(new OpenBrainStore.PendingMessage(
             6400, 88L, "macmini", "linuxserver", content, "pending"));
-        poller.triggerPoll();
+        pump(poller);
         assertEquals(1, proc.processCount.get());
 
         // 25 duplicates over subsequent polls — would otherwise have driven
@@ -937,7 +959,7 @@ class MessagePollerTest {
             brain.inbox.clear();
             brain.inbox.add(new OpenBrainStore.PendingMessage(
                 6500 + i, 88L, "macmini", "linuxserver", content, "pending"));
-            poller.triggerPoll();
+            pump(poller);
         }
 
         assertEquals(1, proc.processCount.get(),
@@ -958,7 +980,7 @@ class MessagePollerTest {
 
         CountingProcessor proc = new CountingProcessor();
         MessagePoller poller = new MessagePoller(cfg, brain, proc);
-        poller.triggerPoll();
+        pump(poller);
 
         assertEquals(1, proc.processCount.get(),
             "only the peer direct message should reach the processor");
@@ -966,5 +988,72 @@ class MessagePollerTest {
         assertEquals(List.of(601), brain.archived);
         assertEquals(List.of(600), brain.watermarks,
             "only the skipped self-broadcast advances the watermark here");
+    }
+
+    // ── messenger#27: cross-thread concurrency ───────────────────────────
+
+    /**
+     * Processor that blocks indefinitely for one designated thread_id (the
+     * "slow" task) and completes instantly for any other thread. Lets us prove
+     * a stuck task on one thread doesn't hold up another.
+     */
+    static class GatedProcessor implements MessageProcessor {
+        final long slowThreadId;
+        final CountDownLatch gate        = new CountDownLatch(1);
+        final CountDownLatch slowStarted = new CountDownLatch(1);
+        final AtomicInteger  fastDone    = new AtomicInteger(0);
+
+        GatedProcessor(long slowThreadId) { this.slowThreadId = slowThreadId; }
+
+        @Override
+        public void process(OpenBrainStore.PendingMessage m) throws Exception {
+            if (m.threadId() == slowThreadId) {
+                slowStarted.countDown();
+                gate.await();              // simulate a long-running agent
+            } else {
+                fastDone.incrementAndGet(); // a quick task on another thread
+            }
+        }
+    }
+
+    /**
+     * Core regression for messenger#27: a long-running task on one thread must
+     * NOT block an unrelated short task on a different thread. This is exactly
+     * the thread 811 (FATS project) vs thread 812 (limerick) scenario.
+     */
+    @Test
+    @Timeout(15)
+    void longTaskOnOneThreadDoesNotBlockAnotherThread() throws Exception {
+        PeerConfig cfg = testConfig("linuxserver");
+        RecordingStore brain = new RecordingStore(cfg);
+        String slow = stampAction("long project kickoff", "macmini", "macmini:811:1");
+        String fast = stampAction("quick limerick please", "macmini", "macmini:812:1");
+        brain.inbox.add(new OpenBrainStore.PendingMessage(811, 811L, "macmini", "linuxserver", slow, "pending"));
+        brain.inbox.add(new OpenBrainStore.PendingMessage(812, 812L, "macmini", "linuxserver", fast, "pending"));
+
+        GatedProcessor proc = new GatedProcessor(811L);
+        MessagePoller poller = new MessagePoller(cfg, brain, proc);
+        poller.triggerPoll();  // NOT pump() — we assert mid-flight, while 811 is still blocked
+
+        assertTrue(proc.slowStarted.await(5, TimeUnit.SECONDS),
+            "the slow task (thread 811) should have started");
+
+        // While 811 is wedged, the fast task on thread 812 must still complete.
+        long deadline = System.nanoTime() + 5_000_000_000L;
+        while (proc.fastDone.get() == 0 && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        assertEquals(1, proc.fastDone.get(),
+            "thread 812 must complete while thread 811 is still blocked (messenger#27)");
+        assertTrue(brain.archived.contains(812),
+            "the fast message should be archived even though the slow one is stuck");
+        assertFalse(brain.archived.contains(811),
+            "the slow message must NOT be archived yet — it's still blocked");
+
+        // Release the slow task and confirm everything drains.
+        proc.gate.countDown();
+        assertTrue(poller.awaitProcessingComplete(5000), "all processing should drain");
+        assertTrue(brain.archived.contains(811),
+            "the slow message archives once it finally finishes");
     }
 }


### PR DESCRIPTION
The primary fix for #27. Part 1 (#29) shipped the isolated robustness fixes; this is the concurrency change that actually ends head-of-line blocking. **Deliberately not yet deployed to the live mesh — opening for review first, per the part-1/part-2 split.**

## Problem
`MessagePoller.poll()` processed each message **inline**, blocking on the `claude -p` subprocess for up to the full timeout. One long task (the FATS kickoff, thread 811) stalled the entire poller, leaving an unrelated connectivity test (thread 812) pending **~18 minutes** — confirmed in the logs (812 replied only after 811 hit its 12-min timeout).

## Change
- **Decouple processing from polling.** `poll()` runs the cheap synchronous filters (status, dedup cache, MAX_TURNS, kind dispatch, NO_REPLY suppression, rate limit) inline, then hands the expensive processor call to a per-thread chain and returns immediately. The poll loop is never blocked.
- **Per-thread serial `CompletableFuture` chains** preserve strict in-arrival-order processing *within* a thread; *different* threads run concurrently on a virtual-thread pool. This replaces the per-thread `ReentrantLock` (which serialised but never parallelised — its own Javadoc claimed cross-thread concurrency it didn't deliver).
- **In-flight set** keyed by `message_id` prevents an overlapping poll from re-dispatching before `markDelivered()` lands.
- **Bounded concurrency** via a new configurable fair semaphore `max_concurrent_processing` (default 4) — so a burst can't exhaust the machine. With default 4, you'd need 4 concurrent long tasks to delay a 5th (vs. 1 today).
- `totalProcessed` → `AtomicInteger`, `lastPollTime` → `volatile`; `stop()` shuts down the pool.

## Interaction with v1.2.0 features (the reason this was deferred)
- **Dedup cache**: sentinel still set post-success (failure → no sentinel → retransmit retries). A duplicate arriving *mid-processing* (rare; retransmits normally arrive after the original finished) would reprocess — consistent with the existing failure-retry semantics. No double-process for the common sequential-retransmit case.
- **MAX_TURNS counter** + dedup check remain synchronous in `poll()`, before dispatch — unchanged behavior.

## Tests
- New regression `longTaskOnOneThreadDoesNotBlockAnotherThread` reproduces 811-vs-812: a blocked task on one thread no longer delays a short task on another. Stable across repeated runs.
- Existing poll/back-compat tests updated to await async drain via a `pump()` helper (processing is no longer synchronous).
- Full suite: **359 passing**.

No wire-protocol change; interoperates with v1.2.x peers, so it can roll out node-by-node.

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)