### PR TITLE
Fix #31 (A+B): harden async-dispatch error paths; v1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hastingtx</groupId>
     <artifactId>messenger</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
     <description>Reliable agent-to-agent messaging daemon. Stores full messages in OpenBrain, delivers wake-up pings, polls every 10 minutes as catchup. Zero external dependencies.</description>
 

--- a/src/main/java/org/hastingtx/meshrelay/MessagePoller.java
+++ b/src/main/java/org/hastingtx/meshrelay/MessagePoller.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -437,12 +438,22 @@ public class MessagePoller implements Runnable {
                         processClaimed(msg);
                     } catch (Throwable t) {
                         // processClaimed handles its own exceptions; last-resort guard.
-                        log.warning("Unexpected error processing message_id=" + msg.messageId()
-                            + " thread_id=" + threadId + ": " + t);
-                    } finally {
-                        inFlight.remove(msg.messageId());
+                        log.log(Level.WARNING, "Unexpected error processing message_id="
+                            + msg.messageId() + " thread_id=" + threadId, t);
                     }
-                }, processingPool);
+                }, processingPool)
+                .whenComplete((r, e) -> {
+                    // Runs on both normal completion AND pool-rejection (when
+                    // thenRunAsync completes the future exceptionally instead of
+                    // submitting the task). This is the only reliable place to
+                    // clear inFlight — the task lambda's finally never runs on
+                    // RejectedExecutionException.
+                    inFlight.remove(msg.messageId());
+                    if (e != null) {
+                        log.log(Level.WARNING, "Dispatch failed for message_id="
+                            + msg.messageId() + " thread_id=" + threadId, e);
+                    }
+                });
             // Prune the map entry once this chain drains, unless a later message
             // has already extended it (then the map holds the newer tail).
             next.whenComplete((r, e) ->
@@ -637,10 +648,10 @@ public class MessagePoller implements Runnable {
             log.info("Processed message thread_id=" + threadId
                 + " from=" + msg.fromNode()
                 + " total_processed=" + processed);
-        } catch (Exception e) {
-            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+        } catch (Throwable t) {
+            if (t instanceof InterruptedException) Thread.currentThread().interrupt();
             log.warning("Failed to process message thread_id=" + threadId
-                + " messageId=" + msg.messageId() + ": " + e.getMessage());
+                + " messageId=" + msg.messageId() + ": " + t.getMessage());
             // Return the message to pending so it can be retried (resetDelivered
             // calls mark_pending). Only if that reset is unavailable do we
             // dead-letter: archive to clear the "delivered" limbo, then log to
@@ -649,7 +660,7 @@ public class MessagePoller implements Runnable {
                 log.warning("Reset unavailable — archiving as dead-letter:"
                     + " thread_id=" + threadId + " messageId=" + msg.messageId());
                 brain.markArchived(msg.messageId());
-                brain.storeDeadLetter(msg, e.getMessage());
+                brain.storeDeadLetter(msg, t.getMessage());
             }
             // If reset succeeded, message returns to pending and will be
             // retried on the next poll cycle.

--- a/src/test/java/org/hastingtx/meshrelay/MessagePollerTest.java
+++ b/src/test/java/org/hastingtx/meshrelay/MessagePollerTest.java
@@ -1056,4 +1056,97 @@ class MessagePollerTest {
         assertTrue(brain.archived.contains(811),
             "the slow message archives once it finally finishes");
     }
+
+    // ── issue #31 A: Throwable (Error) must not strand a message ────────────
+
+    /**
+     * A processor that throws an {@link AssertionError} (or any {@code Error}
+     * not caught by {@code catch (Exception)}) must trigger the
+     * resetDelivered → dead-letter recovery path, not leave the message
+     * stranded in "delivered" limbo.
+     *
+     * <p>Before the fix, {@code Error} escaped {@code processClaimed}'s
+     * {@code catch (Exception)} and was only caught by {@code dispatch}'s
+     * last-resort guard — which only logged and removed the inFlight entry,
+     * leaving the message permanently stuck in "delivered".
+     */
+    @Test
+    @Timeout(10)
+    void processorErrorTriggersDeadLetterNotStrand() {
+        PeerConfig cfg = testConfig("linuxserver");
+
+        final List<Integer> resetCalls     = new CopyOnWriteArrayList<>();
+        final List<Integer> deadLetterIds  = new CopyOnWriteArrayList<>();
+
+        RecordingStore brain = new RecordingStore(cfg) {
+            @Override
+            public boolean resetDelivered(int id) {
+                resetCalls.add(id);
+                return false; // mark_pending unavailable → take dead-letter path
+            }
+            @Override
+            public void storeDeadLetter(PendingMessage msg, String reason) {
+                deadLetterIds.add(msg.messageId());
+            }
+        };
+
+        String content = stampAction("trigger an Error", "macmini", "macmini:9001:1");
+        brain.inbox.add(new OpenBrainStore.PendingMessage(
+            9001, 9001L, "macmini", "linuxserver", content, "pending"));
+
+        MessagePoller poller = new MessagePoller(cfg, brain,
+            msg -> { throw new AssertionError("simulated JVM Error"); });
+        pump(poller);
+
+        assertFalse(resetCalls.isEmpty(),
+            "Error thrown by processor must trigger resetDelivered — not silently strand");
+        assertEquals(List.of(9001), brain.archived,
+            "dead-letter path must archive the message");
+        assertEquals(List.of(9001), deadLetterIds,
+            "storeDeadLetter must be called when resetDelivered returns false");
+        assertEquals(0, poller.inFlightCount(),
+            "inFlight must be clear — no orphaned entry after Error");
+    }
+
+    // ── issue #31 B: RejectedExecutionException must not abort poll batch ───
+
+    /**
+     * When the processing pool is shut down ({@code stop()} called) while
+     * messages are being dispatched, {@code thenRunAsync} throws
+     * {@link RejectedExecutionException}. The remaining messages in the batch
+     * must still be reached, and no inFlight entries must be orphaned.
+     *
+     * <p>Before the fix, the exception propagated through
+     * {@code threadChains.compute()} and out of {@code dispatch()}, aborting
+     * the for-loop in {@code poll()} and leaving any already-added inFlight
+     * entries stranded until daemon restart.
+     */
+    @Test
+    @Timeout(10)
+    void rejectedExecutionOnStoppedPoolDoesNotAbortBatchOrOrphanInFlight() {
+        PeerConfig cfg = testConfig("linuxserver");
+        RecordingStore brain = new RecordingStore(cfg);
+
+        // Two messages; with the pre-fix bug, the first rejection aborts the
+        // loop so the second is never even reached.
+        String c1 = stampAction("message 1", "macmini", "macmini:8001:1");
+        String c2 = stampAction("message 2", "macmini", "macmini:8002:1");
+        brain.inbox.add(new OpenBrainStore.PendingMessage(
+            8001, 8001L, "macmini", "linuxserver", c1, "pending"));
+        brain.inbox.add(new OpenBrainStore.PendingMessage(
+            8002, 8002L, "macmini", "linuxserver", c2, "pending"));
+
+        CountingProcessor proc = new CountingProcessor();
+        MessagePoller poller = new MessagePoller(cfg, brain, proc);
+
+        // Shut down the pool before dispatching — simulates the race where
+        // stop() fires while poll() is mid-batch.
+        poller.stop();
+
+        assertDoesNotThrow(poller::triggerPoll,
+            "RejectedExecutionException must not escape poll() — batch must continue");
+
+        assertEquals(0, poller.inFlightCount(),
+            "inFlight must be empty — no orphaned entries after pool-shutdown rejection");
+    }
 }


### PR DESCRIPTION
Closes #31 (items A and B — the two "Introduced by #30" items only).

## Summary

- **A (priority):** `processClaimed` widened from `catch (Exception e)` to `catch (Throwable t)`. An `Error` thrown by `processor.process()` (OOM, `AssertionError`, `NoClassDefFoundError`) now enters the `resetDelivered → dead-letter` recovery path instead of escaping to `dispatch`'s last-resort guard, which only logged and removed the in-flight entry — leaving the message permanently stranded in `delivered` limbo. Re-interrupts on `InterruptedException`.

- **B:** `inFlight.remove()` moved from the task lambda's `finally` block into a `whenComplete` on the `thenRunAsync` future. The lambda body (including `finally`) never executes when the processing pool rejects the task — `whenComplete` is the only callback guaranteed to fire on both normal completion *and* `RejectedExecutionException`. This prevents orphaned in-flight entries when `stop()` races a poll batch. Also upgraded the last-resort `catch (Throwable t)` log call to `log.log(Level.WARNING, msg, t)` so the full stack trace is captured.

## Key insight (B)

`CompletableFuture.thenRunAsync(task, executor)` — when the executor rejects the task, Java catches `RejectedExecutionException` internally and completes the returned future *exceptionally* (does **not** re-throw). An outer `try/catch (RejectedExecutionException)` around `dispatch()` in `poll()` would be dead code. The fix must be on the future itself, not around the call site.

## Tests added

- `processorErrorTriggersDeadLetterNotStrand` — `AssertionError` thrown by processor reaches `resetDelivered` + `storeDeadLetter`; message is not stranded.
- `rejectedExecutionOnStoppedPoolDoesNotAbortBatchOrOrphanInFlight` — calling `stop()` before a poll cycle leaves `inFlight` empty (no orphaned entries).

## Results

361 tests passing (0 failures, 0 errors). Pre-existing items C/D/E from the checklist are **not** addressed here per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)